### PR TITLE
Update App Server Port

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=Detective Z
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
+server.port=8282


### PR DESCRIPTION
### Set Server Port to 8282 in `application.properties`

- Updated the `server.port` key in the `application.properties` file to `8282`.
- This change ensures that the Spring Boot application will run on port 8282.

#### File Modified:
- `application.properties`
