### PR TITLE
Add Link Field with Validation and Lombok Enhancements to InvestigateDto

### DIFF
--- a/src/main/java/com/fleencorp/detectivez/model/dto/InvestigateDto.java
+++ b/src/main/java/com/fleencorp/detectivez/model/dto/InvestigateDto.java
@@ -1,4 +1,21 @@
 package com.fleencorp.detectivez.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class InvestigateDto {
+
+    @NotNull(message ="URL cant be null")
+    @URL(message = "URL must be valid")
+    @JsonProperty("link")
+    private String link;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=Detective Z
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
+server.port=8282


### PR DESCRIPTION
## Summary
This PR introduces the `link` field to the `InvestigateDto` class and enhances it with serialization/deserialization and validation capabilities. Additionally, the class has been annotated with Lombok annotations to reduce boilerplate code.

## Changes
1. **Added `link` Field**
   - Annotated with `@JsonProperty("link")` for proper serialization and deserialization.

2. **Enhanced `link` Field with Validation**
   - Added `@URL` to ensure the field contains a valid URL.
   - Added `@NotNull` to enforce that the field cannot be null.

3. **Lombok Annotations**
   - Annotated the class with the following Lombok annotations:
     - `@Getter` and `@Setter`: To automatically generate getters and setters.
     - `@NoArgsConstructor` and `@AllArgsConstructor`: To provide constructors for the class, reducing boilerplate code.

## Why These Changes?
- To ensure the `link` field is robust and adheres to validation requirements.
- To simplify the class definition using Lombok, improving maintainability and readability.

---
